### PR TITLE
return the created disposable

### DIFF
--- a/lib/sub-atom.coffee
+++ b/lib/sub-atom.coffee
@@ -20,10 +20,12 @@ class SubAtom
           autoDisposables.dispose()
           @disposables.remove autoDisposables
         @disposables.add autoDisposables
+        autoDisposables
       catch e
         console.log 'SubAtom::add, invalid dispose event', disposeEventObj, disposeEventType, e
     else
       @disposables.add disposable
+      disposable
         
   addElementListener: (ele, events, selector, disposeEventObj, disposeEventType, handler) ->
     if selector


### PR DESCRIPTION
It would be nice to be able to do the following so I can dispose of this one event listener anytime I want.

``` coffee
disposable = @disposables.add(element, event, callback)

# ...

disposable.dispose()
```
